### PR TITLE
Replaced full template string with the URL class

### DIFF
--- a/User.js
+++ b/User.js
@@ -14,13 +14,13 @@ module.exports = class User extends Gitea {
         }
     }
     getUserInfo() {
-        return request.get(`${this.options.url}/api/v1/user?token=${this.token}`).then(r => r.body).catch(() => {
+        return request.get(new URL(`/api/v1/user?token=${this.token}`, this.options.url)).then(r => r.body).catch(() => {
             throw new ReferenceError('Authentication failure, please provide a valid token');
         });
     }
 
     getEmail() {
-        return request.get(`${this.options.url}/api/v1/user/emails?token=${this.token}`).then(r => r.body).catch(() => {
+        return request.get(new URL(`/api/v1/user/emails?token=${this.token}`, this.options.url)).then(r => r.body).catch(() => {
             throw new Reference('Authentication failure, please provide a valid token');
         })
     }


### PR DESCRIPTION
The template string would always fail if the user had their options.url
end with a "/", the URL class fixes this.